### PR TITLE
remove references to mapzen api_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Load both Pelias, and also Transit landmarks (GTFS, intersections from OSM, land
 1. mkdir $DATA_DIR
 1. git clone --recursive https://github.com/OpenTransitTools/pelias.dockerfiles.git
 1. cd pelias.dockerfiles
-1. emacs pelias.json # add your MapZen key where instructed in pelias.json (download WoF data from MapZen)
-1. git update-index --assume-unchanged pelias.json
 1. ./build.sh
 
 Test:
@@ -25,7 +23,7 @@ Update:
 1. ./nuke_containers.sh # use with caution, will drop most / all of your non-Pelias Docker env
 1. ./build.sh
 
-Notes: 
+Notes:
 1. [pelias.transit.loader](https://hub.docker.com/r/opentransittools/pelias.transit.loader/builds/) docker image on Docker Hub
 1. [pelias.transit.loader](https://github.com/OpenTransitTools/pelias.transit.loader) code on GitHub
 1. TriMet's Staging Server Instance: https://ws-st.trimet.org/pelias/v1/search?api_key=YourTriMetApiKey&text=stops%202

--- a/pelias.json
+++ b/pelias.json
@@ -112,7 +112,7 @@
     "openstreetmap": {
       "download": [
         {
-          "sourceURL": "https://s3.amazonaws.com/metro-extracts.mapzen.com/portland_oregon.osm.pbf"
+          "sourceURL": "https://s3.amazonaws.com/missinglink.mapzen/metro-extracts.mapzen.com/portland_oregon.osm.pbf"
         }
       ],
       "leveldbpath": "/tmp",

--- a/pelias.json
+++ b/pelias.json
@@ -133,8 +133,7 @@
       "datapath": "/data/whosonfirst",
       "importVenues": false,
       "importPostalcodes": true,
-      "importPlace": "101715829",
-      "api_key": "<YOUR MAPZEN API KEY HERE>"
+      "importPlace": "101715829"
     },
     "interpolation": {
       "download": {

--- a/pelias.json
+++ b/pelias.json
@@ -112,7 +112,7 @@
     "openstreetmap": {
       "download": [
         {
-          "sourceURL": "https://s3.amazonaws.com/missinglink.mapzen/metro-extracts.mapzen.com/portland_oregon.osm.pbf"
+          "sourceURL": "https://s3.amazonaws.com/metro-extracts.nextzen.org/portland_oregon.osm.pbf"
         }
       ],
       "leveldbpath": "/tmp",


### PR DESCRIPTION
The mapzen WOF API has gone away :(
A replacement system for downloading regions has been implemented, so these settings can be removed.

I also added a second commit to change the download location of the portland 'metro extract' to a mirror.